### PR TITLE
server: terminate connection when on socket close

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -46,6 +46,9 @@ var SPDYProxy = function(options) {
       // write out headers to handle redirects
       res.writeHead(rres.statusCode, '', rres.headers);
       rres.pipe(res);
+
+      // Res could not write, but it could close connection
+      res.pipe(rres);
     });
 
     rreq.on('error', function(e) {
@@ -55,6 +58,10 @@ var SPDYProxy = function(options) {
     });
 
     req.pipe(rreq);
+
+    // Just in case if socket will be shutdown before http.request will connect
+    // to the server.
+    res.pipe(rreq);
   }
 
   function handleSecure(req, socket) {


### PR DESCRIPTION
Probable fix for #3.

The thing is that you're not handling spdy socket's `close` event, you only push data from server to client, regardless of client's status. Secure proxy may also be affected by this, by I haven't checked it yet.
