### PR TITLE
Fix a bug when accessing URLS with non-standard ports

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -49,7 +49,7 @@ var SPDYProxy = function(options) {
   function handlePlain(req, res) {
     var path = req.headers.path || url.parse(req.url).path;
     var requestOptions = {
-      host: req.headers.host,
+      host: req.headers.host.split(':')[0],
       port: req.headers.host.split(':')[1] || 80,
       path: path,
       method: req.method,


### PR DESCRIPTION
Accessing URLS like http://keyserver.ubuntu.com:11371/ will result in "Client error: getaddrinfo ENOTFOUND".

The host name isn't handled correctly. 

Here is the fix.
