### PR TITLE
411 Length Required Error on some sites

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -11,7 +11,7 @@ var SPDYProxy = function(options) {
 
   this.setAuthHandler = function(handler) {
     self._authHandler = handler;
-    console.log('AuthHandler'.green, handler.friendly_name.yellow, 
+    console.log('AuthHandler'.green, handler.friendly_name.yellow,
                 'will be used.'.green);
   }
 
@@ -56,6 +56,11 @@ var SPDYProxy = function(options) {
 
   function handlePlain(req, res) {
     var path = req.headers.path || url.parse(req.url).path;
+
+    // Fix for 411 length required errors
+    // FIXME: Might cause unwanted side-effects?
+    delete req.headers['transfer-encoding'];
+
     var requestOptions = {
       host: req.headers.host.split(':')[0],
       port: req.headers.host.split(':')[1] || 80,


### PR DESCRIPTION
Hi,

Using the latest node-spdyproxy version (`0.2.4`) is causing a `411 Length Required` nginx error on some sites.

Sample site: http://gorillavid.in/ or http://nodejs.org/

Request Headers:

```
GET http://gorillavid.in/ HTTP/1.1
:host: gorillavid.in
accept-charset: ISO-8859-1,utf-8;q=0.7,*;q=0.3
accept-encoding: gzip,deflate,sdch
accept-language: de-DE,de;q=0.8,en-US;q=0.6,en;q=0.4
user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.63 Safari/537.31
:path: /
accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
:version: HTTP/1.1
cache-control: max-age=0
cookie: aff=1658
:scheme: http
:method: GET
```

Response Headers:

```
HTTP/1.1 411 OK
status: 411
version: HTTP/1.1
content-length: 576
content-type: text/html
date: Wed, 29 May 2013 17:47:43 GMT
proxy-agent: SPDY Proxy 0.2.4
server: nginx
```

Proxy output:

```
127.0.0.1:39678 - GET - stream ID: 1 - priority: 0
GET /
 > host: gorillavid.in
 > path: /
 > accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
 > accept-charset: ISO-8859-1,utf-8;q=0.7,*;q=0.3
 > accept-encoding: gzip,deflate,sdch
 > accept-language: de-DE,de;q=0.8,en-US;q=0.6,en;q=0.4
 > cache-control: max-age=0
 > cookie: aff=1658
 > user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.63 Safari/537.31
 > transfer-encoding: chunked
```

Thanks.
