### PR TITLE
Fix undefined property 'remoteAddress'

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -133,8 +133,8 @@ var SPDYProxy = function(options) {
   function handleRequest(req, res) {
     var socket = (req.method == 'CONNECT') ? res : res.socket;
     console.log("%s:%s".yellow + " - %s - " + "stream ID: " + "%s".yellow + " - priority: " + "%s".yellow,
-      socket.connection ? socket.connection.socket.remoteAddress : socket.socket.remoteAddress,
-      socket.connection ? socket.connection.socket.remotePort : socket.socket.remotePort,
+      (socket.connection && socket.connection.socket) ? socket.connection.socket.remoteAddress : (socket.socket ? socket.socket.remoteAddress : "unknown"),
+      (socket.connection && socket.connection.socket) ? socket.connection.socket.remotePort : (socket.socket ? socket.socket.remotePort : -1),
       req.method, res.id || (socket._spdyState && socket._spdyState.id) || "none",
       res.priority || (socket._spdyState && socket._spdyState.priority) || "none"
     );


### PR DESCRIPTION
Sometimes `Error: TypeError: Cannot read property 'remoteAddress' of undefined` occurs, try to fix it.